### PR TITLE
FIX: open_repository() by FQRN on Stratum0

### DIFF
--- a/cvmfs/repository.py
+++ b/cvmfs/repository.py
@@ -157,7 +157,7 @@ class Repository(object):
         if os.path.exists(source):
             return LocalFetcher(source, cache_dir)
         if os.path.exists(os.path.join('/srv/cvmfs', source)):
-            return LocalFetcher(os.path.join('/srv/cvmfs', source, cache_dir))
+            return LocalFetcher(os.path.join('/srv/cvmfs', source), cache_dir)
         else:
             raise RepositoryNotFound(source)
 


### PR DESCRIPTION
Turns out that `cache_dir` should be a parameter of `LocalFetcher()` rather than `os.path.join()`. I'd give three camels for a compiler! :)
