### PR TITLE
Refactor: Allow for custom Fetcher instances

### DIFF
--- a/cvmfs/repository.py
+++ b/cvmfs/repository.py
@@ -172,7 +172,7 @@ class Repository(object):
                 self.manifest = Manifest(manifest_file)
             self.fqrn = self.manifest.repository_name
         except FileNotFoundInRepository, e:
-            raise RepositoryNotFound(self._endpoint)
+            raise RepositoryNotFound(self._fetcher.source)
 
 
     @staticmethod

--- a/cvmfs/repository.py
+++ b/cvmfs/repository.py
@@ -143,7 +143,6 @@ class Repository(object):
         if source == '':
             raise Exception('source cannot be empty')
         self._fetcher = self.__init_fetcher(source, cache_dir)
-        self._endpoint = source
         self._opened_catalogs = {}
         self._read_manifest()
         self._try_to_get_last_replication_timestamp()


### PR DESCRIPTION
This allows the instantiation of a Repository object with a custom Fetcher instance. This is used to make the Fetcher user extensible. I will need this for one of the add-on scripts in the CernVM-FS repository. It is implemented by introducing factory methods to the Repository class.
