### PR TITLE
Add Manifest Field 'A' (Bootstrapping Shortcuts)

### DIFF
--- a/cvmfs/manifest.py
+++ b/cvmfs/manifest.py
@@ -63,6 +63,8 @@ class Manifest(RootFile):
             self.micro_catalog       = data
         elif key_char == "G":
             self.garbage_collectable = (data == "yes")
+        elif key_char == "A":
+            self.bootstrap_shortcuts = (data == "yes")
         else:
             raise UnknownManifestField(key_char)
 


### PR DESCRIPTION
We've introduced a new field in the manifest, i.e. `A[yes|no]` for marking a repository to have 'bootstrapping shortcuts'. See [this CernVM-FS pull request](https://github.com/cvmfs/cvmfs/pull/1291) for more details.
