### PR TITLE
FIX: Print Revision Object

### DIFF
--- a/cvmfs/revision.py
+++ b/cvmfs/revision.py
@@ -128,7 +128,7 @@ class Revision:
         self._tag = tag
 
     def __str__(self):
-        return '<Revision ' + self.revision_number \
+        return '<Revision ' + str(self.revision_number) \
                + ' - ' + self.root_hash + '>'
 
     @property


### PR DESCRIPTION
Type error when doing:

``` python
repo = ...
revision = repo.get_current_revision()
print revision
```
