### PR TITLE
FIX: Add Support for Manifest V and M Fields

### DIFF
--- a/cvmfs/manifest.py
+++ b/cvmfs/manifest.py
@@ -65,6 +65,10 @@ class Manifest(RootFile):
             self.garbage_collectable = (data == "yes")
         elif key_char == "A":
             self.bootstrap_shortcuts = (data == "yes")
+        elif key_char == "M":
+            self.metainfo            = data
+        elif key_char == "V":
+            self.cvmfs_version       = data
         else:
             raise UnknownManifestField(key_char)
 


### PR DESCRIPTION
Adds `M` for meta info object and `V` for CernVM-FS creator version.
