### PR TITLE
Feature: Backtracking File Path from Content Hashes in Catalogs

### DIFF
--- a/cvmfs/catalog.py
+++ b/cvmfs/catalog.py
@@ -263,9 +263,9 @@ class Catalog(DatabaseObject):
     def find_directory_entry_split_md5(self, md5path_1, md5path_2):
         """ Finds the DirectoryEntry for the given split MD5 hashed path """
         res = self.run_sql("SELECT " + DirectoryEntry.catalog_db_fields() + " \
-                            FROM catalog                                       \
-                            WHERE md5path_1 = " + str(md5path_1) + " AND       \
-                                  md5path_2 = " + str(md5path_2) + "           \
+                            FROM catalog                                      \
+                            WHERE md5path_1 = " + str(md5path_1) + " AND      \
+                                  md5path_2 = " + str(md5path_2) + "          \
                             LIMIT 1;")
         return self._make_directory_entry(res[0]) if len(res) == 1 else None
 


### PR DESCRIPTION
This allows to backtrace a CernVM-FS file path for a given content hash. Both _partial objects_ and _bulk chunks_ are fine. Currently this only works on catalog level, not on an entire catalog tree. Furthermore the feature is rather slow, as this catalog lookup is only partially backed by an SQLite index. It's anyway useful for repository backend troubleshooting.

Example:

``` python
import cvmfs
r = cvmfs.open_repository("http://cvmfs-stratum-one.cern.ch/cvmfs/cms.cern.ch")
root_clg = r.get_current_revision().retrieve_root_catalog()
print root_clg.backtrace_content_hash("9a90537c5241495f08bb4e9a73a77f38d837ed9e")
```

Output:

```
['/lcg/SCRAMV1/V2_2_6_pre2/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_5_pre6/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_6_pre5/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_6_pre4/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_5_pre8/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_5_pre3/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_5_pre4/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_6_pre3/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_5_pre5/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_5_pre1/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_5_pre2/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_6_pre1/src/BuildSystem/TemplateInterface.pm',
'/lcg/SCRAMV1/V2_2_5_pre9/src/BuildSystem/TemplateInterface.pm']
```

Note that the result is a list because a single content hash might be referred to by many CernVM-FS paths.
