### PR TITLE
Improve iteration

### DIFF
--- a/cvmfs/catalog.py
+++ b/cvmfs/catalog.py
@@ -46,7 +46,7 @@ class CatalogIterator:
 
 
     def _pop(self):
-        return self.backlog.popleft()
+        return self.backlog.pop()
 
 
     def _recursion_step(self):
@@ -244,7 +244,8 @@ class Catalog(DatabaseObject):
                             WHERE parent_1 = " + str(parent_1) + " AND         \
                                   parent_2 = " + str(parent_2) + "             \
                             ORDER BY name ASC;")
-        return [ self._make_directory_entry(result) for result in res ]
+        for result in res:
+            yield self._make_directory_entry(result)
 
 
     def find_directory_entry(self, path):

--- a/cvmfs/repository.py
+++ b/cvmfs/repository.py
@@ -56,7 +56,7 @@ class Repository(object):
             raise RepositoryNotFound(source)
 
     def __iter__(self):
-        return RevisionIterator(self)
+        return RevisionIterator(self.get_current_revision())
 
     def _read_manifest(self):
         try:


### PR DESCRIPTION
A few improvements to being able to iterate across a revision:
- Fixed a bug that prevented the iteration from working.
- Use generators where possible, instead of building lists.
- Use depth-first-search.  The current algorithm is breadth-first-search, which I found to be problematic when iterating through a directory with many sub-directories, each containing a large number of files.  The full list of files in all the sub-directories would be buffered in memory first as the sub-directories were walked through.
- Provide the ability to filter out unwanted catalogs and callback when a given catalog is completed.

The last one is important because I want to build up a look-aside database; I only need to process each catalog once.  The database is expensive to calculate, so I need a mechanism to identify when I've already processed a catalog and skip it when doing the iteration.