### PR TITLE
add cvmfs-search tool to search cvmfs repos by a content hash in URL format.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     'Topic :: System :: Systems Administration'
   ],
   packages=find_packages(),
-  scripts=['utils/big_catalogs', 'utils/catdirusage'],
+  scripts=['utils/big_catalogs', 'utils/catdirusage', 'utils/cvmfs_search'],
   zip_safe=False,
   test_suite='cvmfs.test',
   tests_require='xmlrunner',

--- a/utils/cvmfs-search
+++ b/utils/cvmfs-search
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+import cvmfs
+import sys
+import os
+import os.path
+import sqlite3
+import time
+
+CACHE_VERSION = "v1"
+
+
+def get_cache_path():
+    path = os.environ.get("XDG_CACHE_HOME", "")
+    if not path.strip():
+        path = os.path.expanduser("~/.cache")
+    path = os.path.join(path, "cvmfs-search", CACHE_VERSION)
+    return path
+
+
+CACHE_PATH = get_cache_path()
+
+
+def index_repo(rev, output):
+    db = sqlite3.connect(output + ".tmp")
+
+    # Create the catalog table.
+    db.execute(
+        """CREATE TABLE catalog (
+            md5path_1 INTEGER,
+            md5path_2 INTEGER,
+            parent_1 INTEGER,
+            parent_2 INTEGER,
+            hash BLOB,
+            name TEXT
+        )"""
+    ).close()
+
+    # Create the indexes.
+    db.execute(
+        """
+        CREATE INDEX catalog_hash
+          ON catalog(hash);
+        """
+    ).close()
+    db.execute(
+        """
+        CREATE INDEX catalog_md5path
+          ON catalog(md5path_1, md5path_2);
+        """
+    ).close()
+
+    for clg in rev.catalogs():
+        print(clg)
+
+        res = clg.run_sql(
+            "SELECT md5path_1, md5path_2, parent_1, parent_2, hash, name FROM catalog"
+        )
+
+        for md5path_1, md5path_2, parent_1, parent_2, content_hash, name in res:
+            db.execute(
+                "INSERT INTO catalog(md5path_1, md5path_2, parent_1, parent_2, hash, name) VALUES (?, ?, ?, ?, ?, ?)",
+                (md5path_1, md5path_2, parent_1, parent_2, content_hash, name),
+            ).close()
+
+    db.commit()
+
+    db.close()
+
+    print("finished indexing")
+
+    time.sleep(5)
+
+    os.rename(output + ".tmp", output)
+
+
+def get_path(db: sqlite3.Connection, parent_1, parent_2):
+    if parent_1 == 0 and parent_2 == 0:
+        return ""
+
+    results = db.execute(
+        "SELECT parent_1, parent_2, name FROM catalog WHERE md5path_1 = ? AND md5path_2 = ? LIMIT 1",
+        (parent_1, parent_2),
+    )
+
+    if results.rowcount == 0:
+        raise Exception("not found")
+
+    for parent_1, parent_2, name in results:
+        parent = get_path(db, parent_1, parent_2)
+        return os.path.join(parent, name)
+
+
+def search_cvmfs_repo(url):
+    repo_url, data_hash = url.split("/data/")
+    data_hash = data_hash.replace("/", "")
+
+    repo = cvmfs.open_repository(repo_url)
+
+    revision = repo.get_current_revision()
+
+    database_cache = os.path.join(CACHE_PATH, revision.root_hash + ".db")
+    if not os.path.exists(database_cache):
+        print("indexing", repo_url)
+        index_repo(revision, database_cache)
+
+    content_hash = bytes.fromhex(data_hash)
+
+    db = sqlite3.connect(database_cache)
+
+    ret = []
+
+    for parent_1, parent_2, name in db.execute(
+        "SELECT parent_1, parent_2, name FROM catalog WHERE hash = ?",
+        (content_hash,),
+    ):
+        path = get_path(db, parent_1, parent_2)
+        ret.append(os.path.join(path, name))
+
+    return ret
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: cvmfs-search <url>")
+        print("search a CVMFS repository for all filepaths that match a given URL.")
+        sys.exit(1)
+
+    if not os.path.exists(CACHE_PATH):
+        os.makedirs(CACHE_PATH)
+
+    names = search_cvmfs_repo(sys.argv[1])
+    for name in names:
+        print(name)

--- a/utils/cvmfs_search
+++ b/utils/cvmfs_search
@@ -6,6 +6,7 @@ import os
 import os.path
 import sqlite3
 import time
+import argparse
 
 CACHE_VERSION = "v1"
 
@@ -21,7 +22,7 @@ def get_cache_path():
 CACHE_PATH = get_cache_path()
 
 
-def index_repo(rev, output):
+def index_repo(rev, output, enable_index=True):
     db = sqlite3.connect(output + ".tmp")
 
     # Create the catalog table.
@@ -36,19 +37,20 @@ def index_repo(rev, output):
         )"""
     ).close()
 
-    # Create the indexes.
-    db.execute(
-        """
-        CREATE INDEX catalog_hash
-          ON catalog(hash);
-        """
-    ).close()
-    db.execute(
-        """
-        CREATE INDEX catalog_md5path
-          ON catalog(md5path_1, md5path_2);
-        """
-    ).close()
+    if enable_index:
+        # Create the indexes.
+        db.execute(
+            """
+            CREATE INDEX catalog_hash
+            ON catalog(hash);
+            """
+        ).close()
+        db.execute(
+            """
+            CREATE INDEX catalog_md5path
+            ON catalog(md5path_1, md5path_2);
+            """
+        ).close()
 
     for clg in rev.catalogs():
         print(clg)
@@ -91,7 +93,7 @@ def get_path(db: sqlite3.Connection, parent_1, parent_2):
         return os.path.join(parent, name)
 
 
-def search_cvmfs_repo(url):
+def search_cvmfs_repo(url, enable_index=True):
     repo_url, data_hash = url.split("/data/")
     data_hash = data_hash.replace("/", "")
 
@@ -102,7 +104,7 @@ def search_cvmfs_repo(url):
     database_cache = os.path.join(CACHE_PATH, revision.root_hash + ".db")
     if not os.path.exists(database_cache):
         print("indexing", repo_url)
-        index_repo(revision, database_cache)
+        index_repo(revision, database_cache, enable_index=enable_index)
 
     content_hash = bytes.fromhex(data_hash)
 
@@ -121,14 +123,21 @@ def search_cvmfs_repo(url):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("usage: cvmfs-search <url>")
-        print("search a CVMFS repository for all filepaths that match a given URL.")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Search CVMFS repositories for all files matching a given download URL."
+    )
+    parser.add_argument("url", type=str, help="A CVMFS URL to print the paths for.")
+    parser.add_argument(
+        "--db-index",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Add indexes to the created SQLite database. If you disable this the catalog will be created faster and take less disk space but searching will be slower. (Enabled by default)",
+    )
+    args = parser.parse_args()
 
     if not os.path.exists(CACHE_PATH):
         os.makedirs(CACHE_PATH)
 
-    names = search_cvmfs_repo(sys.argv[1])
+    names = search_cvmfs_repo(args.url, args.db_index)
     for name in names:
         print(name)


### PR DESCRIPTION
`cvmfs-search` will automatically create a local SQLite database indexing a CVMFS repo by merging all the catalogs together. It can then be used to search for file paths with a given content hash in URL format (for instance gotten from server request logs).

**Example**: `./cvmfs-search http://stratum0.neurodesk.cloud.edu.au/cvmfs/neurodesk.ardc.edu.au/data/ce/5f9de12bc279218e151c1b9bf21a88ed048dad` outputs `containers/bidsapppymvpa_2.0.2_20230629/bidsapppymvpa_2.0.2_20230629.simg/usr/lib/python2.7/dist-packages/openpyxl/xml/tests/test_functions.py`

If one content hash matches multiple files it will print all files.

It can take a while to index large repositories. Some of this is inherent with the amount of data being indexed but if you are in a hurry you can comment out the 2 `CREATE INDEX` statements. Once a repo is indexed it will keep using that index until the root catalog hash changes.