### PR TITLE
require python3 at build time for EL8

### DIFF
--- a/rpm/python-cvmfsutils.spec
+++ b/rpm/python-cvmfsutils.spec
@@ -14,6 +14,7 @@ BuildArch: noarch
 Vendor: Rene Meusel <rene.meusel@cern.ch>
 Url: http://cernvm.cern.ch
 
+BuildRequires: python3
 BuildRequires: python3-rpm-macros
 BuildRequires: python3-setuptools
 


### PR DESCRIPTION
It works without this on el7 and el9 but not on el8.