### PR TITLE
Go back to using "%{name}" in spec instead of "cvmfsutils"

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -26,9 +26,6 @@ jobs:
     - name: Install setuptools-scm
       run: pip install setuptools-scm
 
-    - name: Generate RPM spec file
-      run: python generate_spec.py
-
     - name: Get version from spec
       id: version
       run: |
@@ -86,10 +83,14 @@ jobs:
         # Setup RPM build tree
         mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
-        # Copy source tarball to SOURCES (renamed to match spec version)
-        cp "dist/cvmfsutils-${VERSION}.tar.gz" ~/rpmbuild/SOURCES/
+        # Rename source paths and make source tarball in SOURCES
+        cd dist
+        tar xzf cvmfsutils-${VERSION}.tar.gz
+        mv cvmfsutils-${VERSION} python-cvmfsutils-${VERSION}
+        tar czf ~/rpmbuild/SOURCES/python-cvmfsutils-${VERSION}.tar.gz python-cvmfsutils-${VERSION}
+        cd ..
 
-        # Copy spec file to SPECS (now includes version, no macros needed)
+        # Copy spec file to SPECS
         cp rpm/python-cvmfsutils.spec ~/rpmbuild/SPECS/
 
         # Build the RPM (no version macro needed since it's in the spec file)
@@ -190,10 +191,14 @@ jobs:
         # Setup RPM build tree
         mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
-        # Copy source tarball to SOURCES (renamed to match spec version)
-        cp "dist/cvmfsutils-${VERSION}.tar.gz" ~/rpmbuild/SOURCES/
+        # Rename source paths and make source tarball in SOURCES
+        cd dist
+        tar xzf cvmfsutils-${VERSION}.tar.gz
+        mv cvmfsutils-${VERSION} python-cvmfsutils-${VERSION}
+        tar czf ~/rpmbuild/SOURCES/python-cvmfsutils-${VERSION}.tar.gz python-cvmfsutils-${VERSION}
+        cd ..
 
-        # Copy spec file to SPECS (already has version embedded)
+        # Copy spec file to SPECS
         cp rpm/python-cvmfsutils.spec ~/rpmbuild/SPECS/
 
         # Build the RPM (set topdir since SUSE defaults to /usr/src/packages)

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -33,13 +33,3 @@ jobs:
           diff /tmp/checked-in.spec rpm/python-cvmfsutils.spec || true
           exit 1
         fi
-
-    - name: Verify spec file has no external macros
-      run: |
-        # Check that the spec file doesn't use %{version} macro
-        if grep -q "%{version}" rpm/python-cvmfsutils.spec; then
-          echo "✗ Spec file still contains %{version} macro - should be replaced with actual version"
-          exit 1
-        else
-          echo "✓ Spec file does not use external version macro"
-        fi

--- a/rpm/python-cvmfsutils.spec
+++ b/rpm/python-cvmfsutils.spec
@@ -5,7 +5,7 @@ Summary: Inspect CernVM-FS repositories
 Name: python-cvmfsutils
 Version: 0.6.0
 Release: %{release_prefix}%{?dist}
-Source0: cvmfsutils-0.6.0.tar.gz
+Source0: %{name}-0.6.0.tar.gz
 License: (c) 2015 CERN - BSD License
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-0.6.0-%{release}-buildroot
@@ -31,13 +31,13 @@ files) and the history of named snapshots inside any CernVM-FS repository.
 
 %prep
 #%%setup -n %{name}-0.6.0 -n %{name}-0.6.0
-%autosetup -n cvmfsutils-0.6.0
+%autosetup -n %{name}-0.6.0
 
 %build
 # No build step needed - pip install handles everything
 
 %install
-python3 -m pip install --no-deps --root=%{buildroot} %{_sourcedir}/cvmfsutils-0.6.0.tar.gz
+python3 -m pip install --no-deps --root=%{buildroot} %{_sourcedir}/%{name}-0.6.0.tar.gz
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/rpm/python-cvmfsutils.spec.in
+++ b/rpm/python-cvmfsutils.spec.in
@@ -5,7 +5,7 @@ Summary: Inspect CernVM-FS repositories
 Name: python-cvmfsutils
 Version: @VERSION@
 Release: %{release_prefix}%{?dist}
-Source0: cvmfsutils-@VERSION@.tar.gz
+Source0: %{name}-@VERSION@.tar.gz
 License: (c) 2015 CERN - BSD License
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-@VERSION@-%{release}-buildroot
@@ -31,13 +31,13 @@ files) and the history of named snapshots inside any CernVM-FS repository.
 
 %prep
 #%%setup -n %{name}-@VERSION@ -n %{name}-@VERSION@
-%autosetup -n cvmfsutils-@VERSION@
+%autosetup -n %{name}-@VERSION@
 
 %build
 # No build step needed - pip install handles everything
 
 %install
-python3 -m pip install --no-deps --root=%{buildroot} %{_sourcedir}/cvmfsutils-@VERSION@.tar.gz
+python3 -m pip install --no-deps --root=%{buildroot} %{_sourcedir}/%{name}-@VERSION@.tar.gz
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Need to continue to use `%{name}` in spec file after #40, because the OpenSUSE Build System gets its source file using the github standard tarball download which takes package name appended with a hyphen and the version.  The tar file name itself is easy enough to change, but the problem is the top level directory inside of that tarball is always the full package name+hyphen+version.