### PR TITLE
feat: replace M2Crypto with cryptography library

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        alma-version: ["8", "9"]
+        alma-version: ["8", "9", "10"]
     container:
       image: almalinux:${{ matrix.alma-version }}
 
@@ -58,10 +58,8 @@ jobs:
       timeout-minutes: 10
       run: |
         dnf update -y
-        # Enable EPEL repository for python3-m2crypto
-        dnf install -y epel-release
-        dnf install -y git rpm-build rpm-devel python3-pip python3-devel
-        dnf install -y python3-requests python3-dateutil python3-m2crypto
+        dnf install -y git rpm-build rpm-devel python3-pip python3-devel python3-setuptools
+        dnf install -y python3-requests python3-dateutil python3-cryptography
 
         # Enable PowerTools/CRB for additional packages
         if [ "${{ matrix.alma-version }}" = "8" ]; then
@@ -173,7 +171,7 @@ jobs:
       run: |
         zypper refresh
         zypper install -y tar gzip git rpm-build python3-pip python3-devel python3-setuptools
-        zypper install -y python3-requests python3-dateutil python3-M2Crypto
+        zypper install -y python3-requests python3-dateutil python3-cryptography
 
     - uses: actions/checkout@v4
 

--- a/generate_spec.py
+++ b/generate_spec.py
@@ -21,11 +21,13 @@ def extract_version_from_changelog(template_content):
     Changelog entries look like:
         * Wed Aug 13 2025 Chris Burr <...> - 0.6.0-1
 
+    Commented entries (starting with #) are skipped.
+
     Returns the version (e.g., "0.6.0").
     """
-    # Find the %changelog section and the first entry
+    # Find the %changelog section and the first non-commented entry
     changelog_match = re.search(
-        r"%changelog\s*\n\*.*-\s*(\d+\.\d+\.?\d*)-\d+",
+        r"%changelog\s*\n(?:(?:#[^\n]*)?\n)*\*.*-\s*(\d+\.\d+\.?\d*)-\d+",
         template_content,
     )
     if not changelog_match:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ platforms = ["linux-64", "osx-64", "osx-arm64"]
 
 [tool.pixi.dependencies]
 python = ">=3.8"
-m2crypto = "*"
+cryptography = "*"
 pip = "*"
 setuptools-scm = "*"
 

--- a/rpm/python-cvmfsutils.spec
+++ b/rpm/python-cvmfsutils.spec
@@ -21,11 +21,7 @@ BuildRequires: python3-setuptools
 
 Requires: python3-dateutil
 Requires: python3-requests
-%if 0%{?suse_version}
-Requires: python3-M2Crypto
-%else
-Requires: python3-m2crypto
-%endif
+Requires: python3-cryptography
 
 %description
 The CernVM-FS python package allows for the inspection of CernVM-FS
@@ -53,6 +49,8 @@ rm -rf $RPM_BUILD_ROOT
 %{python3_sitelib}/*
 
 %changelog
+# - Replace M2Crypto dependency with cryptography library
+
 * Wed Aug 13 2025 Chris Burr <christopher.burr@cern.ch> - 0.6.0-1
 - Modernize build system to use pyproject.toml with setuptools
 - Use setuptools-scm for version management

--- a/rpm/python-cvmfsutils.spec.in
+++ b/rpm/python-cvmfsutils.spec.in
@@ -21,11 +21,7 @@ BuildRequires: python3-setuptools
 
 Requires: python3-dateutil
 Requires: python3-requests
-%if 0%{?suse_version}
-Requires: python3-M2Crypto
-%else
-Requires: python3-m2crypto
-%endif
+Requires: python3-cryptography
 
 %description
 The CernVM-FS python package allows for the inspection of CernVM-FS
@@ -53,6 +49,8 @@ rm -rf $RPM_BUILD_ROOT
 %{python3_sitelib}/*
 
 %changelog
+# - Replace M2Crypto dependency with cryptography library
+
 * Wed Aug 13 2025 Chris Burr <christopher.burr@cern.ch> - 0.6.0-1
 - Modernize build system to use pyproject.toml with setuptools
 - Use setuptools-scm for version management

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python_requires = >=3.6
 install_requires =
     python-dateutil >= 1.4.1
     requests >= 1.1.0
-    m2crypto >= 0.20.0
+    cryptography >= 3.3
 
 [options.packages.find]
 where = src

--- a/src/cvmfs/certificate.py
+++ b/src/cvmfs/certificate.py
@@ -4,15 +4,20 @@ Created by René Meusel
 This file is part of the CernVM File System auxiliary tools.
 """
 
-from M2Crypto import X509, RSA
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
 
 class Certificate:
     """ Wraps an X.509 certificate object as stored in CVMFS repositories """
 
     def __init__(self, certificate_file):
         self._certificate_file = certificate_file
-        cert = X509.load_cert_string(self._certificate_file.read())
-        self.openssl_certificate = cert
+        cert_data = self._certificate_file.read()
+        if isinstance(cert_data, str):
+            cert_data = cert_data.encode()
+        self.openssl_certificate = x509.load_pem_x509_certificate(cert_data)
 
     def __str__(self):
         return "<Certificate " + self.get_fingerprint() + ">"
@@ -21,25 +26,30 @@ class Certificate:
         return self.__str__()
 
     def get_openssl_certificate(self):
-        """ return the certificate as M2Crypto.X509 object """
+        """ return the certificate as cryptography.x509.Certificate object """
         return self.openssl_certificate
 
     def get_fingerprint(self, algorithm='sha1'):
         """ returns the fingerprint of the X509 certificate """
-        fp = self.openssl_certificate.get_fingerprint(algorithm)
-        return ':'.join([ x + y for x, y in zip(fp[0::2], fp[1::2]) ])
+        if algorithm == 'sha1':
+            hash_algo = hashes.SHA1()
+        elif algorithm == 'sha256':
+            hash_algo = hashes.SHA256()
+        else:
+            raise ValueError(f"Unsupported hash algorithm: {algorithm}")
+        fp = self.openssl_certificate.fingerprint(hash_algo)
+        return ':'.join(f'{b:02X}' for b in fp)
 
     def verify(self, signature, message):
         """ verify a given signature to an expected 'message' string """
-        pubkey = self.openssl_certificate.get_pubkey()
-        # Can't use cert signature verify on EL9 because sha1 certs are
-        # disabled by default.
-        # Should convert to using cryptography instead of M2Crypto
-        # and use the RSAPublicKey recover_data_from_signature() function.
-        pubkey.reset_context(md='sha1')
-        pubkey.verify_init()
-        pubkey.verify_update(message.encode())
-        result = pubkey.verify_final(signature)
-        if result > 0:
+        pubkey = self.openssl_certificate.public_key()
+        try:
+            pubkey.verify(
+                signature,
+                message.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA1()
+            )
             return True
-        return False
+        except Exception:
+            return False

--- a/src/cvmfs/test/certificate_test.py
+++ b/src/cvmfs/test/certificate_test.py
@@ -8,7 +8,7 @@ import base64
 import unittest
 import zlib
 
-from M2Crypto.X509 import X509
+from cryptography.x509 import Certificate as X509Certificate
 
 from .file_sandbox import FileSandbox
 import cvmfs
@@ -51,7 +51,7 @@ class TestCertificate(unittest.TestCase):
         with open(self.certificate_file) as cert_file:
             cert = cvmfs.Certificate(cert_file)
             x509 = cert.get_openssl_certificate()
-            self.assertTrue(isinstance(x509, X509))
+            self.assertTrue(isinstance(x509, X509Certificate))
 
 
     def test_verify_message(self):

--- a/src/cvmfs/test/mock_repository.py
+++ b/src/cvmfs/test/mock_repository.py
@@ -12,12 +12,52 @@ import io
 import tarfile
 import threading
 
-from M2Crypto import RSA
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 
 import http.server
 import socketserver
 
 from .file_sandbox import FileSandbox
+
+
+def _rsa_private_encrypt(private_key, data):
+    """
+    Perform raw RSA private key encryption (equivalent to M2Crypto's private_encrypt).
+
+    This is a non-standard operation used for signature schemes where the
+    recipient recovers the original data using public_decrypt/recover_data_from_signature.
+    """
+    from cryptography.hazmat.primitives.asymmetric.rsa import (
+        rsa_crt_iqmp, rsa_crt_dmp1, rsa_crt_dmq1
+    )
+    from cryptography.hazmat.backends import default_backend
+
+    # Get key size in bytes
+    key_size_bytes = (private_key.key_size + 7) // 8
+
+    # PKCS#1 v1.5 padding: 0x00 0x01 [padding 0xFF bytes] 0x00 [data]
+    # Minimum padding is 8 bytes of 0xFF
+    padding_len = key_size_bytes - len(data) - 3
+    if padding_len < 8:
+        raise ValueError("Data too long for key size")
+
+    padded = b'\x00\x01' + (b'\xff' * padding_len) + b'\x00' + data
+
+    # Convert padded message to integer
+    padded_int = int.from_bytes(padded, byteorder='big')
+
+    # Get private key numbers for raw RSA operation
+    private_numbers = private_key.private_numbers()
+    d = private_numbers.d
+    n = private_numbers.public_numbers.n
+
+    # Perform raw RSA: signature = message^d mod n
+    sig_int = pow(padded_int, d, n)
+
+    # Convert back to bytes
+    return sig_int.to_bytes(key_size_bytes, byteorder='big')
 
 class CvmfsTestServer(socketserver.TCPServer):
     allow_reuse_address = True
@@ -87,8 +127,10 @@ class MockRepository:
             new_wl.write("--\n".encode())
             new_wl.write(wl_hash.hexdigest().encode())
             new_wl.write("\n".encode())
-            key = RSA.load_key(self.master_key)
-            sig = key.private_encrypt(wl_hash.hexdigest().encode(), RSA.pkcs1_padding)
+            with open(self.master_key, 'rb') as key_file:
+                key = serialization.load_pem_private_key(key_file.read(), password=None)
+            data = wl_hash.hexdigest().encode()
+            sig = _rsa_private_encrypt(key, data)
             new_wl.write(sig)
         os.rename(new_whitelist, old_whitelist)
 

--- a/src/cvmfs/whitelist.py
+++ b/src/cvmfs/whitelist.py
@@ -6,7 +6,8 @@ This file is part of the CernVM File System auxiliary tools.
 
 from datetime import datetime
 from dateutil.tz import tzutc
-from M2Crypto import RSA
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 
 import re
 
@@ -88,14 +89,19 @@ class Whitelist(RootFile):
 
 
     def _verify_signature(self, public_key_path):
-        pubkey = RSA.load_pub_key(public_key_path)
+        with open(public_key_path, 'rb') as key_file:
+            pubkey = serialization.load_pem_public_key(key_file.read())
         try:
-            decrypted = pubkey.public_decrypt(self.signature, RSA.pkcs1_padding)
-            if decrypted is None:
+            recovered = pubkey.recover_data_from_signature(
+                self.signature,
+                padding.PKCS1v15(),
+                algorithm=None
+            )
+            if recovered is None:
                 return False
-            sig_sum = decrypted.decode()
+            sig_sum = recovered.decode()
             return sig_sum == self.signature_checksum
-        except RSA.RSAError as e:
+        except Exception:
             return False
 
 


### PR DESCRIPTION
## Summary
- Replace M2Crypto dependency with cryptography library for better platform support
- Add custom `_rsa_private_encrypt()` helper for signature generation in tests
- Use `recover_data_from_signature()` for whitelist signature verification
- Remove EPEL dependency from CI workflow (cryptography is in base repos)

Closes #42