### PR TITLE
feat: support SHAKE128 hashes in manifest and catalog parsing

### DIFF
--- a/src/cvmfs/catalog.py
+++ b/src/cvmfs/catalog.py
@@ -12,6 +12,7 @@ import os
 
 from ._common import _split_md5, DatabaseObject
 from .dirent  import DirectoryEntry, Chunk
+from .root_file import parse_hash_string
 
 
 class CatalogIterator:
@@ -62,10 +63,11 @@ class CatalogIterator:
 class CatalogReference:
     """ Wraps a catalog reference to nested catalogs as found in Catalogs """
 
-    def __init__(self, root_path, clg_hash, clg_size = 0):
+    def __init__(self, root_path, clg_hash, clg_size = 0, algorithm = 'sha1'):
         self.root_path = root_path
         self.hash      = clg_hash
         self.size      = clg_size
+        self.algorithm = algorithm
 
     def __str__(self):
         return "<CatalogReference for " + self.root_path + " - " + self.hash + ">"
@@ -74,7 +76,7 @@ class CatalogReference:
         return "<CatalogReference for " + self.root_path + ">"
 
     def retrieve_from(self, source_repository):
-        return source_repository.retrieve_catalog(self.hash)
+        return source_repository.retrieve_catalog(self.hash, self.algorithm)
 
 
 
@@ -192,10 +194,18 @@ class Catalog(DatabaseObject):
         else:
             sql_query = "SELECT path, sha1 FROM nested_catalogs;"
         catalogs = self.run_sql(sql_query)
-        if new_version:
-            return [ CatalogReference(clg[0], clg[1], clg[2]) for clg in catalogs ]
-        else:
-            return [ CatalogReference(clg[0], clg[1]) for clg in catalogs ]
+        # The "sha1" column holds hex text that may be bare (historical SHA-1)
+        # or "<hex>-<algo>" per-entry. In mixed repositories migrated from SHA1
+        # to SHAKE128, both forms can coexist in a single table, so parse each
+        # row independently and carry the algorithm on the reference.
+        refs = []
+        for clg in catalogs:
+            ref_hash, ref_algo = parse_hash_string(clg[1])
+            if new_version:
+                refs.append(CatalogReference(clg[0], ref_hash, clg[2], ref_algo))
+            else:
+                refs.append(CatalogReference(clg[0], ref_hash, algorithm=ref_algo))
+        return refs
 
 
     def get_statistics(self):

--- a/src/cvmfs/manifest.py
+++ b/src/cvmfs/manifest.py
@@ -7,12 +7,22 @@ This file is part of the CernVM File System auxiliary tools.
 from datetime import datetime
 from dateutil.tz import tzutc
 
-from .root_file import RootFile
+from .root_file import RootFile, parse_hash_string
 from ._exceptions import *
 
 
 class Manifest(RootFile):
     """ Wraps information from .cvmfspublished """
+
+    def _store_content_hash(self, attr, raw):
+        """Strip the optional "-<algo>" suffix and record the hash algorithm.
+
+        Content-addressed paths (data/xx/yyyy...C) are constructed from the bare
+        hex digest, so downstream consumers expect the stripped form.
+        """
+        hex_digest, algorithm = parse_hash_string(raw)
+        setattr(self, attr, hex_digest)
+        self.hash_algorithm = algorithm
 
     @staticmethod
     def open(manifest_path):
@@ -45,15 +55,15 @@ class Manifest(RootFile):
         key_char = line[0]
         data     = line[1:-1]
         if   key_char == "C":
-            self.root_catalog        = data
+            self._store_content_hash('root_catalog', data)
         elif key_char == "R":
             self.root_hash           = data
         elif key_char == "B":
             self.root_catalog_size   = int(data)
         elif key_char == "X":
-            self.certificate         = data
+            self._store_content_hash('certificate', data)
         elif key_char == "H":
-            self.history_database    = data
+            self._store_content_hash('history_database', data)
         elif key_char == "T":
             self.last_modified       = datetime.fromtimestamp(int(data), tz=tzutc())
         elif key_char == "D":
@@ -63,13 +73,13 @@ class Manifest(RootFile):
         elif key_char == "N":
             self.repository_name     = data
         elif key_char == "L":
-            self.micro_catalog       = data
+            self._store_content_hash('micro_catalog', data)
         elif key_char == "G":
             self.garbage_collectable = (data == "yes")
         elif key_char == "A":
             self.bootstrap_shortcuts = (data == "yes")
         elif key_char == "M":
-            self.repoinfo            = data
+            self._store_content_hash('repoinfo', data)
         elif key_char == "V":
             self.cvmfs_version       = data
         elif key_char == "Y":

--- a/src/cvmfs/repository.py
+++ b/src/cvmfs/repository.py
@@ -157,16 +157,31 @@ class Repository(object):
         certificate = self.retrieve_object(self.manifest.certificate, 'X')
         return Certificate(certificate)
 
-    def retrieve_catalog(self, catalog_hash):
+    def retrieve_catalog(self, catalog_hash, algorithm=None):
         """ Download and open a catalog from the repository """
         if catalog_hash in self._opened_catalogs:
             return self._opened_catalogs[catalog_hash]
-        return self._retrieve_and_open_catalog(catalog_hash)
+        return self._retrieve_and_open_catalog(catalog_hash, algorithm)
 
-    def retrieve_object(self, object_hash, hash_suffix = ''):
+    def retrieve_object(self, object_hash, hash_suffix='', algorithm=None):
         """ Retrieves an object from the content addressable storage """
-        path = "data/" + object_hash[:2] + "/" + object_hash[2:] + hash_suffix
+        path = "data/" + object_hash[:2] + "/" + object_hash[2:] + self.hash_algo_infix(algorithm) + hash_suffix
         return self._fetcher.retrieve_file(path)
+
+    def get_object_size(self, object_hash, hash_suffix='', algorithm=None):
+        """ Gets the compressed size of an object without downloading it """
+        path = "data/" + object_hash[:2] + "/" + object_hash[2:] + self.hash_algo_infix(algorithm) + hash_suffix
+        return self._fetcher.get_file_size(path)
+
+    def hash_algo_infix(self, algorithm=None):
+        """Return the "-<algo>" CAS-path segment for non-SHA1 hashes, or "".
+
+        When algorithm is None, falls back to the manifest's algorithm.
+        Pass per-reference algorithms explicitly for mixed-mode repos.
+        """
+        if algorithm is None:
+            algorithm = getattr(self.manifest, 'hash_algorithm', 'sha1')
+        return '' if algorithm == 'sha1' else '-' + algorithm
 
     def close_catalog(self, catalog):
         try:
@@ -174,8 +189,8 @@ class Repository(object):
         except KeyError as e:
             print("not found:" , catalog.hash)
 
-    def _retrieve_and_open_catalog(self, catalog_hash):
-        catalog_file = self.retrieve_object(catalog_hash, 'C')
+    def _retrieve_and_open_catalog(self, catalog_hash, algorithm=None):
+        catalog_file = self.retrieve_object(catalog_hash, 'C', algorithm)
         new_catalog = Catalog(catalog_file, catalog_hash)
         self._opened_catalogs[catalog_hash] = new_catalog
         return new_catalog

--- a/src/cvmfs/root_file.py
+++ b/src/cvmfs/root_file.py
@@ -22,8 +22,45 @@ binary string containing the private-key signature terminated by EOF.
 
 import abc
 import hashlib
+import re
 
 from ._exceptions import *
+
+
+_HEX40_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# Content-hash algorithms CVMFS may suffix onto hex digests (e.g. "abcd...-shake128").
+# Values are either an `hashlib` factory (for algorithms we verify signatures with) or
+# None (for algorithms we only need to recognise in hash-bearing fields).
+_HASH_ALGORITHMS = {
+    "sha1": hashlib.sha1,
+    "shake128": hashlib.shake_128,
+    "rmd160": None,
+}
+
+
+def parse_hash_string(raw):
+    """Split a CVMFS hash string into (hex_digest, algorithm).
+
+    CVMFS writes content hashes as "<40-hex>" for SHA-1 (the historical default) and
+    as "<40-hex>-<algo>" for newer algorithms such as SHAKE128. Returns the bare
+    40-character hex digest and the algorithm name ("sha1" when no suffix is present).
+
+    Raises IncompleteRootFileSignature if the hex portion is not 40 lowercase hex
+    characters or the algorithm suffix is unrecognised.
+    """
+    raw = raw.strip()
+    if "-" in raw:
+        hex_part, _, algo = raw.partition("-")
+    else:
+        hex_part, algo = raw, "sha1"
+    if not _HEX40_RE.match(hex_part):
+        raise IncompleteRootFileSignature("Hash malformed: " + raw)
+    if algo not in _HASH_ALGORITHMS:
+        raise IncompleteRootFileSignature(
+            "Unsupported hash algorithm '" + algo + "' in: " + raw
+        )
+    return hex_part, algo
 
 
 class RootFile(metaclass=abc.ABCMeta):
@@ -63,29 +100,44 @@ class RootFile(metaclass=abc.ABCMeta):
 
 
     @staticmethod
-    def _hash_over_content(file_object):
-        pos = file_object.tell()
-        hash_sum = hashlib.sha1()
-        while True:
-            line = file_object.readline()
-            if line.decode()[0:2] == "--":
-                break
-            if pos == file_object.tell():
-                raise IncompleteRootFileSignature("Signature not found")
-            hash_sum.update(line)
-            pos = file_object.tell()
+    def _hash_bytes(content, algorithm):
+        """Hash the key-value block (everything before the "--" terminator).
+
+        'content' is the raw bytes of the signed portion of the root file.
+        'algorithm' selects the digest function; SHAKE128 is an XOF and is
+        truncated to 20 bytes (40 hex chars) to match CVMFS's SHAKE128-160.
+        """
+        factory = _HASH_ALGORITHMS.get(algorithm)
+        if factory is None:
+            raise IncompleteRootFileSignature(
+                "Cannot verify signature with algorithm: " + algorithm
+            )
+        hash_sum = factory()
+        hash_sum.update(content)
+        if algorithm == "shake128":
+            return hash_sum.hexdigest(20)
         return hash_sum.hexdigest()
 
 
     def _read_signature(self, file_object):
         """ Reads the signature's checksum and the binary signature string """
         file_object.seek(0)
-        message_digest = self._hash_over_content(file_object)
+        content = bytearray()
+        while True:
+            line = file_object.readline()
+            if not line:
+                raise IncompleteRootFileSignature("Signature not found")
+            if line[0:2] == b"--":
+                break
+            content.extend(line)
+        if not content:
+            raise IncompleteRootFileSignature("Signature not found")
 
         self.signature_checksum = file_object.readline().decode().rstrip()
-        if len(self.signature_checksum) != 40:
-            raise IncompleteRootFileSignature("Signature checksum malformed")
-        if message_digest != self.signature_checksum:
+        hex_digest, algorithm = parse_hash_string(self.signature_checksum)
+        self.signature_hash_algorithm = algorithm
+
+        if self._hash_bytes(bytes(content), algorithm) != hex_digest:
             raise InvalidRootFileSignature("Signature checksum doesn't match")
         self.signature = file_object.read()
         if len(self.signature) == 0:

--- a/src/cvmfs/test/__main__.py
+++ b/src/cvmfs/test/__main__.py
@@ -28,6 +28,7 @@ from .whitelist_test    import *
 from .md5_handling_test import *
 from .certificate_test  import *
 from .repository_test   import *
+from .shake128_test     import *
 
 import optparse
 import sys

--- a/src/cvmfs/test/manifest_test.py
+++ b/src/cvmfs/test/manifest_test.py
@@ -6,6 +6,7 @@ This file is part of the CernVM File System auxiliary tools.
 
 import base64
 import datetime
+import hashlib
 import io
 import unittest
 import zlib
@@ -296,3 +297,58 @@ class TestManifest(unittest.TestCase):
         cert = cvmfs.Certificate(open(self.certificate_file))
         is_valid = manifest.verify_signature(cert)
         self.assertFalse(is_valid)
+
+
+    def _build_shake128_manifest(self, mutate_checksum=None):
+        body_lines = [
+            b'Cca091b24e7a2a466592a71511cf9f5fae04a7263-shake128',
+            b'B10516480',
+            b'Rd41d8cd98f00b204e9800998ecf8427e',
+            b'D240',
+            b'S10652',
+            b'Nsoft.computecanada.ca',
+            b'Xa9938e06a2d59d9c3fff179305ae7133129e5e12-shake128',
+            b'H413244736cd260c23ef26f9086baaf1b8e4bc59d-shake128',
+            b'T1776803048',
+            b'M4bbaa296efcd2692075061aac3fe74a90141c9ef-shake128',
+            b'Gyes',
+            b'Ano',
+            b'Yb5c937ed0a846bf9d060054cfab0fe6ed7aa96c5-shake128',
+        ]
+        content = b'\n'.join(body_lines) + b'\n'
+        checksum = hashlib.shake_128(content).hexdigest(20) + '-shake128'
+        if mutate_checksum is not None:
+            checksum = mutate_checksum(checksum)
+        return io.BytesIO(
+            content + b'--\n' + checksum.encode() + b'\nBINARY-SIGNATURE-BYTES'
+        )
+
+    def test_shake128_manifest(self):
+        manifest = cvmfs.Manifest(self._build_shake128_manifest())
+        self.assertEqual('ca091b24e7a2a466592a71511cf9f5fae04a7263', manifest.root_catalog)
+        self.assertEqual('a9938e06a2d59d9c3fff179305ae7133129e5e12', manifest.certificate)
+        self.assertEqual('413244736cd260c23ef26f9086baaf1b8e4bc59d', manifest.history_database)
+        self.assertEqual('4bbaa296efcd2692075061aac3fe74a90141c9ef', manifest.repoinfo)
+        self.assertEqual('soft.computecanada.ca', manifest.repository_name)
+        self.assertEqual('shake128', manifest.hash_algorithm)
+        self.assertEqual('shake128', manifest.signature_hash_algorithm)
+        self.assertTrue(manifest.signature_checksum.endswith('-shake128'))
+        self.assertEqual(b'BINARY-SIGNATURE-BYTES', manifest.signature)
+
+    def test_shake128_mismatched_checksum(self):
+        stream = self._build_shake128_manifest(
+            mutate_checksum=lambda s: '0' * 40 + '-shake128'
+        )
+        self.assertRaises(cvmfs.InvalidRootFileSignature, cvmfs.Manifest, stream)
+
+    def test_shake128_unknown_algorithm(self):
+        stream = self._build_shake128_manifest(
+            mutate_checksum=lambda s: s.rsplit('-', 1)[0] + '-sha999'
+        )
+        self.assertRaises(cvmfs.IncompleteRootFileSignature, cvmfs.Manifest, stream)
+
+    def test_shake128_malformed_hex(self):
+        stream = self._build_shake128_manifest(
+            mutate_checksum=lambda s: 'zz' + s[2:]
+        )
+        self.assertRaises(cvmfs.IncompleteRootFileSignature, cvmfs.Manifest, stream)

--- a/src/cvmfs/test/shake128_test.py
+++ b/src/cvmfs/test/shake128_test.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for SHAKE128 content-hash support.
+"""
+
+import hashlib
+import io
+import unittest
+
+import cvmfs
+from cvmfs.catalog import CatalogReference
+from cvmfs.root_file import parse_hash_string
+
+
+class TestParseHashString(unittest.TestCase):
+    def test_bare_hex_is_sha1(self):
+        hex_digest, algo = parse_hash_string(
+            "044206fcff4545283aaa452b80edfd5d8c740b20"
+        )
+        self.assertEqual(hex_digest, "044206fcff4545283aaa452b80edfd5d8c740b20")
+        self.assertEqual(algo, "sha1")
+
+    def test_shake128_suffix(self):
+        hex_digest, algo = parse_hash_string(
+            "ca091b24e7a2a466592a71511cf9f5fae04a7263-shake128"
+        )
+        self.assertEqual(hex_digest, "ca091b24e7a2a466592a71511cf9f5fae04a7263")
+        self.assertEqual(algo, "shake128")
+
+    def test_rmd160_suffix_is_recognised(self):
+        # rmd160 is listed as recognised (no hashlib factory) so that manifests
+        # using it parse without error even when we can't verify their signatures.
+        hex_digest, algo = parse_hash_string(
+            "0123456789abcdef0123456789abcdef01234567-rmd160"
+        )
+        self.assertEqual(algo, "rmd160")
+        self.assertEqual(hex_digest, "0123456789abcdef0123456789abcdef01234567")
+
+    def test_strips_surrounding_whitespace(self):
+        hex_digest, algo = parse_hash_string(
+            "  044206fcff4545283aaa452b80edfd5d8c740b20\n"
+        )
+        self.assertEqual(hex_digest, "044206fcff4545283aaa452b80edfd5d8c740b20")
+        self.assertEqual(algo, "sha1")
+
+    def test_rejects_short_hex(self):
+        self.assertRaises(
+            cvmfs.IncompleteRootFileSignature, parse_hash_string, "abcd"
+        )
+
+    def test_rejects_uppercase_hex(self):
+        self.assertRaises(
+            cvmfs.IncompleteRootFileSignature,
+            parse_hash_string,
+            "044206FCFF4545283AAA452B80EDFD5D8C740B20",
+        )
+
+    def test_rejects_unknown_algorithm(self):
+        self.assertRaises(
+            cvmfs.IncompleteRootFileSignature,
+            parse_hash_string,
+            "044206fcff4545283aaa452b80edfd5d8c740b20-md5",
+        )
+
+    def test_rejects_empty_hex_before_suffix(self):
+        self.assertRaises(
+            cvmfs.IncompleteRootFileSignature, parse_hash_string, "-shake128"
+        )
+
+
+class _StubManifest:
+    def __init__(self, algorithm):
+        self.hash_algorithm = algorithm
+
+
+class _StubRepository:
+    """Minimum surface of Repository needed to exercise hash_algo_infix."""
+
+    def __init__(self, algorithm):
+        self.manifest = _StubManifest(algorithm)
+
+    # Borrow the real implementation so we're testing the code that ships.
+    from cvmfs.repository import Repository
+
+    hash_algo_infix = Repository.hash_algo_infix
+
+
+class TestHashAlgoInfix(unittest.TestCase):
+    def test_sha1_manifest_no_infix(self):
+        repo = _StubRepository("sha1")
+        self.assertEqual(repo.hash_algo_infix(), "")
+        self.assertEqual(repo.hash_algo_infix("sha1"), "")
+
+    def test_shake128_manifest_adds_infix(self):
+        repo = _StubRepository("shake128")
+        self.assertEqual(repo.hash_algo_infix(), "-shake128")
+
+    def test_explicit_algorithm_overrides_manifest(self):
+        repo = _StubRepository("shake128")
+        self.assertEqual(repo.hash_algo_infix("sha1"), "")
+        repo = _StubRepository("sha1")
+        self.assertEqual(repo.hash_algo_infix("shake128"), "-shake128")
+
+    def test_defaults_to_sha1_when_manifest_lacks_algorithm(self):
+        class _EmptyManifest:
+            pass
+
+        repo = _StubRepository("sha1")
+        repo.manifest = _EmptyManifest()
+        self.assertEqual(repo.hash_algo_infix(), "")
+
+
+class TestCatalogReferenceAlgorithm(unittest.TestCase):
+    def test_default_algorithm_is_sha1(self):
+        ref = CatalogReference("/sw", "044206fcff4545283aaa452b80edfd5d8c740b20")
+        self.assertEqual(ref.algorithm, "sha1")
+
+    def test_algorithm_preserved(self):
+        ref = CatalogReference(
+            "/.cvmfs",
+            "b81dd6309454da7d3c88345e3425e452ea399c21",
+            51200,
+            "shake128",
+        )
+        self.assertEqual(ref.algorithm, "shake128")
+
+    def test_retrieve_from_passes_algorithm(self):
+        # Verify CatalogReference.retrieve_from forwards its algorithm to
+        # Repository.retrieve_catalog, so mixed-mode repos route each nested
+        # catalog through the correct CAS path.
+        ref = CatalogReference("/x", "a" * 40, 0, "shake128")
+        received = {}
+
+        class _FakeRepo:
+            def retrieve_catalog(self, catalog_hash, algorithm=None):
+                received["hash"] = catalog_hash
+                received["algorithm"] = algorithm
+                return "catalog"
+
+        self.assertEqual(ref.retrieve_from(_FakeRepo()), "catalog")
+        self.assertEqual(received["hash"], "a" * 40)
+        self.assertEqual(received["algorithm"], "shake128")
+
+
+class TestMixedModeListNested(unittest.TestCase):
+    """Nested catalog references may carry per-entry hash algorithms.
+
+    When a repository is migrated from SHA-1 to SHAKE128 (e.g. ilc.desy.de),
+    old nested catalogs keep a bare-hex value in the schema-named "sha1"
+    column while new ones carry "<hex>-shake128". list_nested must parse
+    each row independently so the CAS path is correct for every reference.
+    """
+
+    def _build_catalog(self, nested_rows):
+        import os
+        import sqlite3
+        import tempfile
+
+        fd, path = tempfile.mkstemp(suffix=".catalog")
+        os.close(fd)
+        conn = sqlite3.connect(path)
+        conn.executescript(
+            """
+            CREATE TABLE properties (key TEXT, value TEXT);
+            INSERT INTO properties VALUES ('schema', '2.5');
+            INSERT INTO properties VALUES ('schema_revision', '7');
+            INSERT INTO properties VALUES ('revision', '1');
+            INSERT INTO properties VALUES ('last_modified', '1700000000');
+            INSERT INTO properties VALUES ('root_prefix', '/');
+            CREATE TABLE nested_catalogs (path TEXT, sha1 TEXT, size INTEGER);
+            """
+        )
+        conn.executemany(
+            "INSERT INTO nested_catalogs (path, sha1, size) VALUES (?, ?, ?)",
+            nested_rows,
+        )
+        conn.commit()
+        conn.close()
+        self.addCleanup(os.remove, path)
+        # Catalog takes a file object it can .name / .close.
+        return cvmfs.Catalog(open(path, "rb"))
+
+    def test_mixed_sha1_and_shake128_rows(self):
+        catalog = self._build_catalog([
+            ("/sw", "6cac522bbdb433fd9bbd7d22f3c607d45cd547c1", 4044800),
+            ("/.cvmfs", "b81dd6309454da7d3c88345e3425e452ea399c21-shake128", 51200),
+        ])
+        refs = {r.root_path: r for r in catalog.list_nested()}
+        self.assertEqual(
+            refs["/sw"].hash, "6cac522bbdb433fd9bbd7d22f3c607d45cd547c1"
+        )
+        self.assertEqual(refs["/sw"].algorithm, "sha1")
+        self.assertEqual(
+            refs["/.cvmfs"].hash,
+            "b81dd6309454da7d3c88345e3425e452ea399c21",
+        )
+        self.assertEqual(refs["/.cvmfs"].algorithm, "shake128")
+
+
+class TestShake128Whitelist(unittest.TestCase):
+    def _build_whitelist(self):
+        body_lines = [
+            b"20260422000000",
+            b"E20260523000000",
+            b"Nsoft.computecanada.ca",
+            b"C1:2C:2F:7B:B6:8E:82:CF:50:8A:1D:2B:05:5F:14:1B:69:E6:44:E4",
+        ]
+        content = b"\n".join(body_lines) + b"\n"
+        checksum = hashlib.shake_128(content).hexdigest(20) + "-shake128"
+        return io.BytesIO(
+            content + b"--\n" + checksum.encode() + b"\nSIGNATURE-BYTES"
+        )
+
+    def test_shake128_whitelist_parses(self):
+        whitelist = cvmfs.Whitelist(self._build_whitelist())
+        self.assertEqual(whitelist.repository_name, "soft.computecanada.ca")
+        self.assertEqual(whitelist.signature_hash_algorithm, "shake128")
+        self.assertTrue(whitelist.signature_checksum.endswith("-shake128"))
+        self.assertEqual(whitelist.signature, b"SIGNATURE-BYTES")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hopefully supports the issue reported in https://github.com/cvmfs-contrib/cvmfs-catalog-visualizations/pull/8#issuecomment-4284424184